### PR TITLE
Fixed missing 'A' issue

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_example/README.md
+++ b/farmdata2_modules/fd2_tabs/fd2_example/README.md
@@ -75,7 +75,7 @@ To add a new sub-tab to the `xyz` module:
 
 ### JavaScript and CSS Libraries ###
 
-JavaScript and CSS libraries can be included in module by adding them to the module configuration files (i.e. `.info` and `.module`).  
+JavaScript and CSS libraries can be included in a module by adding them to the module configuration files (i.e. `.info` and `.module`).  
 
 #### Local Libraries ####
 


### PR DESCRIPTION
__Pull Request Description__

Fixed the missing "a" typo

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.

Fixes #1 
